### PR TITLE
Work towards library handle sharing

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,10 +1,9 @@
----
 name: Python Flake8 Code Quality
 
-on:
-  - push
-  - pull_request
-  - fork
+# on:
+#   - push
+#   - pull_request
+#   - fork
 
 jobs:
   flake8:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
----
 name: Publish Python distributions to PyPI
 
-on:
-  release:
-    types: [published]
+# on:
+#   release:
+#     types: [published]
+
 jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,9 @@
----
 name: Test
 
-on:
-  - push
-  - pull_request
-  - fork
+# on:
+#   - push
+#   - pull_request
+#   - fork
 
 jobs:
   setup-and-test:

--- a/ctypesgen/__main__.py
+++ b/ctypesgen/__main__.py
@@ -19,6 +19,7 @@ from ctypesgen import (
 from ctypesgen.printer_python import WrapperPrinter as PythonPrinter
 from ctypesgen.printer_json import WrapperPrinter as JsonPrinter
 
+
 @contextlib.contextmanager
 def tmp_searchpath(path, active):
     if active:
@@ -32,16 +33,22 @@ def tmp_searchpath(path, active):
         yield
         return
 
+
 def find_symbols_in_modules(modnames, outpath):
+    
     symbols = set()
+    
     for modname in modnames:
+        
         include_path = str(outpath.parents[1].resolve())
         with tmp_searchpath(include_path, active=modname.startswith(".")):
             module = importlib.import_module(modname, outpath.parent.name)
+        
         module_syms = [s for s in dir(module) if not re.fullmatch(r"__\w+__", s)]
         assert len(module_syms) > 0, "Linked modules must provide symbols"
         msgs.status_message(f"Found symbols {module_syms} in module {module}")
         symbols.update(module_syms)
+    
     return symbols
 
 

--- a/ctypesgen/__main__.py
+++ b/ctypesgen/__main__.py
@@ -53,6 +53,7 @@ def find_symbols_in_modules(modnames, outpath):
 
 
 # FIXME argparse parameters are not ordered consistently...
+# TODO consider BooleanOptionalAction (with compat backport)
 def main(givenargs=None):
     
     parser = argparse.ArgumentParser()

--- a/ctypesgen/__main__.py
+++ b/ctypesgen/__main__.py
@@ -365,8 +365,9 @@ def main(givenargs=None):
     parser.set_defaults(**core_options.default_values)
     args = parser.parse_args(givenargs)
     
-    args.compile_libdirs += args.universal_libdirs
-    args.runtime_libdirs += args.universal_libdirs
+    # important: must not use +=, this would mutate the original object, which is problematic when calling ctypesgen natively from the python API
+    args.compile_libdirs = args.compile_libdirs + args.universal_libdirs
+    args.runtime_libdirs = args.runtime_libdirs + args.universal_libdirs
     
     # Figure out what names will be defined by imported Python modules
     args.imported_symbols = find_symbols_in_modules(args.modules, Path(args.output))

--- a/ctypesgen/__main__.py
+++ b/ctypesgen/__main__.py
@@ -15,9 +15,9 @@ from ctypesgen import (
     parser as core_parser,
     processor,
     version,
+    printer_python,
+    printer_json,
 )
-from ctypesgen.printer_python import WrapperPrinter as PythonPrinter
-from ctypesgen.printer_json import WrapperPrinter as JsonPrinter
 
 
 @contextlib.contextmanager
@@ -373,7 +373,9 @@ def main(givenargs=None):
     # Figure out what names will be defined by imported Python modules
     args.imported_symbols = find_symbols_in_modules(args.modules, Path(args.output))
     
-    printer = {"py": PythonPrinter, "json": JsonPrinter}[args.output_language]
+    printer = {
+        "py": printer_python, "json": printer_json
+    }[args.output_language].WrapperPrinter
     
     descriptions = core_parser.parse(args.headers, args)
     processor.process(descriptions, args)

--- a/ctypesgen/libraryloader.py
+++ b/ctypesgen/libraryloader.py
@@ -47,4 +47,4 @@ def _register_library(name, dllclass, **kwargs):
     libpath = _find_library(name, **kwargs)
     assert libpath, "output expected from _find_library()"
     _libs_info[name] = {"name": name, "dllclass": dllclass, **kwargs, "path": libpath}
-    return dllclass(libpath)
+    _libs[name] = dllclass(libpath)

--- a/ctypesgen/libraryloader.py
+++ b/ctypesgen/libraryloader.py
@@ -47,4 +47,4 @@ def _register_library(name, dllclass, **kwargs):
     libpath = _find_library(name, **kwargs)
     assert libpath, "output expected from _find_library()"
     _libs_info[name] = {"name": name, "dllclass": dllclass, **kwargs, "path": libpath}
-    return getattr(ctypes, dllclass)(libpath)
+    return dllclass(libpath)

--- a/ctypesgen/libraryloader.py
+++ b/ctypesgen/libraryloader.py
@@ -44,8 +44,7 @@ def _find_library(name, dirs, search_sys, reldir=None):
 _libs_info, _libs = {}, {}
 
 def _register_library(name, dllclass, **kwargs):
-    _libs_info[name] = {"name": name, "dllclass": dllclass, **kwargs}
-    _libs_info[name]["path"] = _find_library(name, **kwargs)
-    if not _libs_info[name]["path"]:
-        raise ImportError(f"Could not find library with config {_libs_info[name]}")
-    return getattr(ctypes, dllclass)(_libs_info[name]["path"])
+    libpath = _find_library(name, **kwargs)
+    assert libpath, "output expected from _find_library()"
+    _libs_info[name] = {"name": name, "dllclass": dllclass, **kwargs, "path": libpath}
+    return getattr(ctypes, dllclass)(libpath)

--- a/ctypesgen/libraryloader.py
+++ b/ctypesgen/libraryloader.py
@@ -41,6 +41,3 @@ def _find_library(name, dirs, search_sys, reldir=None):
         return libpath
     else:
         raise ImportError(f"Could not find library '{name}' in {dirs} (system search disabled)")
-
-
-_libs_info, _libs = {}, {}

--- a/ctypesgen/libraryloader.py
+++ b/ctypesgen/libraryloader.py
@@ -13,18 +13,18 @@ def _find_library(name, dirs, search_sys, reldir=None):
     else:  # assume unix pattern or plain name
         patterns = ["lib{}.so", "{}.so", "{}"]
     
-    if not reldir:
+    if reldir is None:
         try:
             reldir = pathlib.Path(__file__).parent
         except NameError as e:
-            # Issue a warning if unable to determine the containing directory. After this, it's OK to just fail with NameError below if actually attempting to resolve a relative path.
             assert e.name == "__file__"
-            warnings.warn("Bindings not stored as file, will be unable to resolve relative dirs")
+            reldir = None
     
     for dir in dirs:
         dir = pathlib.Path(dir)
         if not dir.is_absolute():
-            # note, joining an absolute path silently discardy the path before
+            # NOTE joining an absolute path silently discardy the path before
+            assert reldir != None, "cannot resolve relative paths without anchor point (__file__ not defined?)"
             dir = (reldir/dir).resolve(strict=False)
         for pat in patterns:
             libpath = dir / pat.format(name)

--- a/ctypesgen/libraryloader.py
+++ b/ctypesgen/libraryloader.py
@@ -4,7 +4,6 @@ import ctypes.util
 import warnings
 import pathlib
 
-
 def _find_library(name, dirs, search_sys, reldir=None):
     
     if sys.platform in ("win32", "cygwin", "msys"):
@@ -41,3 +40,12 @@ def _find_library(name, dirs, search_sys, reldir=None):
         return libpath
     else:
         raise ImportError(f"Could not find library '{name}' in {dirs} (system search disabled)")
+
+_libs_info, _libs = {}, {}
+
+def _register_library(name, dllclass, **kwargs):
+    _libs_info[name] = {"name": name, "dllclass": dllclass, **kwargs}
+    _libs_info[name]["path"] = _find_library(name, **kwargs)
+    if not _libs_info[name]["path"]:
+        raise ImportError(f"Could not find library with config {_libs_info[name]}")
+    return getattr(ctypes, dllclass)(_libs_info[name]["path"])

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -94,7 +94,7 @@ class WrapperPrinter:
         content = f"""
 {self.lib_access} = _register_library(
     name = '{self.options.library}',
-    dirs = {opts.runtime_libdirs},
+    dirs = {list(set(opts.runtime_libdirs))},
     search_sys = {opts.allow_system_search},
     dllclass = '{opts.dllclass}',
 )

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -27,13 +27,14 @@ class WrapperPrinter:
         
         try:
             self.options = options
+            self.lib_access = f"_libs['{self.options.library}']"
             
             # FIXME(geisserml) see below
             if self.options.strip_build_path and self.options.strip_build_path[-1] != os.path.sep:
                 self.options.strip_build_path += os.path.sep
             
             if not self.options.embed_preamble:
-                self._copy_preamble_loader_files(outpath)
+                self._write_external_files(outpath)
             
             self.print_header()
             self.file.write("\n")
@@ -76,32 +77,30 @@ class WrapperPrinter:
             self.file.write("# Begin loader template\n\n")
             with LIBRARYLOADER_PATH.open("r") as loader_file:
                 shutil.copyfileobj(loader_file, self.file)
-            self.file.write("\n# End loader template")
+            self.file.write("\n\n# End loader template")
         else:
             self.file.write("from .ctypes_loader import *\n")
-            self.file.write("from .ctypes_loader import _find_library\n\n")
+            self.file.write("from .ctypes_loader import _find_library, _libs_info, _libs\n\n")
 
     def print_library(self, opts):
         if not opts.library:
             notice = "No library name specified. Assuming pure headers without binary symbols."
             warning_message(notice, cls="usage")
-            self.file.write(f'\nwarnings.warn("{notice}")\n')
+            self.file.write(f"\nwarnings.warn('{notice}')\n")
         
         else:
             loader_info = dict(
-                libname = opts.library,
-                libdirs = opts.runtime_libdirs,
-                allow_system_search = opts.allow_system_search,
+                name = self.options.library,
+                dirs = opts.runtime_libdirs,
+                search_sys = opts.allow_system_search,
             )
+            LI = f'_libs_info["{self.options.library}"]'
             self.file.write(f"""
-# Begin library load
-
-_loader_info = {loader_info}
-_loader_info["libpath"] = _find_library(**_loader_info)
-assert _loader_info["libpath"], "Could not find library with config %s" % (_loader_info, )
-_lib = ctypes.{opts.dllclass}(_loader_info["libpath"])
-
-# End library load
+{LI} = {loader_info}
+{LI}['path'] = _find_library(**{LI})
+if not {LI}['path']:
+    raise ImportError("Could not find library with config %s" % ({LI}, ))
+{self.lib_access} = ctypes.{opts.dllclass}({LI}['path'])
 """
             )
     
@@ -169,28 +168,30 @@ _lib = ctypes.{opts.dllclass}(_loader_info["libpath"])
             self.file.write("from .ctypes_preamble import _variadic_function\n")
         self.file.write("\n# End preamble\n")
 
-    def _copy_preamble_loader_files(self, path):
+    def _write_external_files(self, path):
         dst = Path(path).resolve().parent
         shutil.copyfile(PREAMBLE_PATH, dst/"ctypes_preamble.py")
         shutil.copyfile(LIBRARYLOADER_PATH, dst/"ctypes_loader.py")
 
     def print_module(self, module):
         self.file.write("from %s import *\n" % module)
-
+    
     def print_constant(self, constant):
         self.srcinfo(constant.src, wants_nl=False)
         self.file.write("%s = %s" % (constant.name, constant.value.py_string(False)))
+    
+    def _try_except_wrap(self, entry):
+        pad = " "*4
+        return f"try:\n{indent(entry, pad)}\nexcept Exception:\n{pad}pass"
 
     def print_undef(self, undef):
-        # TODO remove try/except, or use only if --guard-symbols given
         self.srcinfo(undef.src)
-        self.file.write(
-            "# #undef {macro}\n"
-            "try:\n"
-            "    del {macro}\n"
-            "except NameError:\n"
-            "    pass".format(macro=undef.macro.py_string(False))
-        )
+        name = undef.macro.py_string(False)
+        self.file.write(f"# undef {name}\n")
+        entry = f"del {name}"
+        if self.options.guard_macros:
+            entry = self._try_except_wrap(entry)
+        self.file.write(entry)
 
     def print_typedef(self, typedef):
         self.srcinfo(typedef.src, wants_nl=False)
@@ -260,20 +261,17 @@ _lib = ctypes.{opts.dllclass}(_loader_info["libpath"])
         # NOTE Values of enumerator are output as constants
         self.file.write("enum_%s = c_int" % enum.tag)
     
-    def _check_guard(self, symbol):
+    def _needs_guard(self, symbol):
         needs_guard = self.options.guard_symbols or getattr(symbol, "is_missing", False)
-        pad = " "*4 if needs_guard else ""
-        return needs_guard, pad
-    
-    def _try_except_wrap(self, entry, pad):
-        return f"try:\n{indent(entry, pad)}\nexcept Exception:\n{pad}pass"
+        return needs_guard
     
     def print_function(self, function):
         self.srcinfo(function.src)
-        needs_guard, pad = self._check_guard(function)
+        needs_guard = self._needs_guard(function)
+        pad = " "*4 if needs_guard else ""
         if needs_guard:
             self.file.write(
-                'if hasattr(_lib, "{CN}"):\n'.format(CN=function.c_name())
+                'if hasattr({L}, "{CN}"):\n'.format(L=self.lib_access, CN=function.c_name())
             )
         if function.variadic:
             self._print_variadic_function(function, pad)
@@ -283,7 +281,7 @@ _lib = ctypes.{opts.dllclass}(_loader_info["libpath"])
     
     def _print_fixed_function(self, function, pad):
         self.file.write(indent(
-            '{PN} = _lib.{CN}\n'.format(CN=function.c_name(), PN=function.py_name()) +
+            '{PN} = {L}.{CN}\n'.format(L=self.lib_access, CN=function.c_name(), PN=function.py_name()) +
             "{PN}.argtypes = [{ATS}]\n".format(PN=function.py_name(), ATS=", ".join([a.py_string() for a in function.argtypes])) +
             "{PN}.restype = {RT}".format(PN=function.py_name(), RT=function.restype.py_string()),
             prefix=pad,
@@ -296,11 +294,12 @@ _lib = ctypes.{opts.dllclass}(_loader_info["libpath"])
     def _print_variadic_function(self, function, pad):
         # TODO see if we can remove the _variadic_function wrapper and use just plain ctypes
         self.file.write(indent(
-            '_func = _lib.{CN}\n'
+            '_func = {L}.{CN}\n'
             "_restype = {RT}\n"
             "_errcheck = {E}\n"
             "_argtypes = [{ATS}]\n"
             "{PN} = _variadic_function(_func,_restype,_argtypes,_errcheck)\n".format(
+                L=self.lib_access,
                 CN=function.c_name(),
                 RT=function.restype.py_string(),
                 E=function.errcheck.py_string(),
@@ -312,14 +311,14 @@ _lib = ctypes.{opts.dllclass}(_loader_info["libpath"])
 
     def print_variable(self, variable):
         self.srcinfo(variable.src)
-        entry = '{PN} = ({PS}).in_dll(_lib, "{CN}")'.format(
+        entry = '{PN} = ({PS}).in_dll({L}, "{CN}")'.format(
             PN=variable.py_name(),
             PS=variable.ctype.py_string(),
+            L=self.lib_access,
             CN=variable.c_name(),
         )
-        needs_guard, pad = self._check_guard(variable)
-        if needs_guard:
-            entry = self._try_except_wrap(entry, pad)
+        if self._needs_guard(variable):
+            entry = self._try_except_wrap(entry)
         self.file.write(entry)
 
     def print_macro(self, macro):
@@ -333,7 +332,7 @@ _lib = ctypes.{opts.dllclass}(_loader_info["libpath"])
         self.srcinfo(macro.src, wants_nl=self.options.guard_macros)
         entry = "{MN} = {ME}".format(MN=macro.name, ME=macro.expr.py_string(True))
         if self.options.guard_macros:
-            entry = self._try_except_wrap(entry, " "*4)
+            entry = self._try_except_wrap(entry)
         self.file.write(entry)
 
     def print_func_macro(self, macro):

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -35,6 +35,7 @@ class WrapperPrinter:
                 self.options.strip_build_path += os.path.sep
             
             if not self.options.embed_preamble:
+                # TODO merge EXT_LOADER and EXT_LIBS
                 self.EXT_PREAMBLE = outpath.parent / "_ctg_preamble.py"
                 self.EXT_LOADER = outpath.parent / "_ctg_loader.py"
                 self.EXT_LIBS = outpath.parent / "_ctg_libs.py"
@@ -98,6 +99,7 @@ class WrapperPrinter:
             search_sys = opts.allow_system_search,
         )
         LI = f"_libs_info['{self.options.library}']"
+        # TODO move to libraryloader function
         content = f"""
 {LI} = {loader_info}
 {LI}['path'] = _find_library(**{LI})

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -28,6 +28,7 @@ class WrapperPrinter:
         
         try:
             self.options = options
+            # TODO remove .lib_access, spell out in functions?
             self.lib_access = f"_libs['{self.options.library}']"
             
             # FIXME(geisserml) see below

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -94,9 +94,9 @@ class WrapperPrinter:
         content = f"""
 {self.lib_access} = _register_library(
     name = '{self.options.library}',
+    dllclass = ctypes.{opts.dllclass},
     dirs = {opts.runtime_libdirs},
     search_sys = {opts.allow_system_search},
-    dllclass = '{opts.dllclass}',
 )
 """
         if self.options.embed_preamble:

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -91,9 +91,10 @@ class WrapperPrinter:
             warning_message("No library name specified. Assuming pure headers without binary symbols.", cls="usage")
             return
         
+        name_define = f"name = '{self.options.library}'"
         content = f"""
-{self.lib_access} = _register_library(
-    name = '{self.options.library}',
+_register_library(
+    {name_define},
     dllclass = ctypes.{opts.dllclass},
     dirs = {opts.runtime_libdirs},
     search_sys = {opts.allow_system_search},
@@ -103,7 +104,7 @@ class WrapperPrinter:
             self.file.write(content)
         else:
             loader_txt = self.EXT_LOADER.read_text()
-            if f"{self.lib_access} = _register_library(" in loader_txt:
+            if name_define in loader_txt:
                 status_message(f"Library already loaded in shared file, won't rewrite.")
             else:
                 status_message(f"Adding library loader to shared file.")

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -94,7 +94,7 @@ class WrapperPrinter:
         content = f"""
 {self.lib_access} = _register_library(
     name = '{self.options.library}',
-    dirs = {list(set(opts.runtime_libdirs))},
+    dirs = {opts.runtime_libdirs},
     search_sys = {opts.allow_system_search},
     dllclass = '{opts.dllclass}',
 )

--- a/ctypesgen/processor/operations.py
+++ b/ctypesgen/processor/operations.py
@@ -108,9 +108,9 @@ def fix_conflicting_names(data, opts):
     occupied_names = occupied_names.union(
         # ctypesgen names
         [
-            "_lib",
-            "_variadic_function",
+            "_libs",
             "_loader_info",
+            "_variadic_function",
             # the following names are only accessed before the symbols list, so we don't strictly care about them being overridden
             # "sys",
             # "warnings",

--- a/ctypesgen/processor/operations.py
+++ b/ctypesgen/processor/operations.py
@@ -109,7 +109,7 @@ def fix_conflicting_names(data, opts):
         # ctypesgen names
         [
             "_libs",
-            "_loader_info",
+            "_libs_info",
             "_variadic_function",
             # the following names are only accessed before the symbols list, so we don't strictly care about them being overridden
             # "sys",

--- a/ctypesgen/processor/operations.py
+++ b/ctypesgen/processor/operations.py
@@ -245,8 +245,14 @@ def check_symbols(data, opts):
         return
 
     try:
-        libpath = libraryloader._find_library(opts.library, opts.compile_libdirs, opts.allow_system_search, reldir=Path.cwd())
-        library = ctypes.CDLL(libpath)
+        libraryloader._register_library(
+            name = opts.library,
+            dllclass = opts.dllclass,
+            dirs = list(set(opts.compile_libdirs)),
+            search_sys = opts.allow_system_search,
+            reldir = Path.cwd(),
+        )
+        library = libraryloader._libs[opts.library]
     except Exception:
         warning_message(f"Could not load library '{opts.library}'. Okay, I'll try to load it at runtime instead.", cls="missing-library")
         return

--- a/ctypesgen/processor/operations.py
+++ b/ctypesgen/processor/operations.py
@@ -116,6 +116,7 @@ def fix_conflicting_names(data, opts):
             # "warnings",
             # "pathlib",
             # "_find_library",
+            # "_register_library",
         ]
     )
     occupied_names = occupied_names.union(
@@ -253,11 +254,12 @@ def check_symbols(data, opts):
             reldir = Path.cwd(),
         )
         library = libraryloader._libs[opts.library]
-    except Exception:
+    except ImportError as e:
+        warning_message(e)
         warning_message(f"Could not load library '{opts.library}'. Okay, I'll try to load it at runtime instead.", cls="missing-library")
         return
     
-    # only check symbols that we actually want to include
+    # don't bother checking symbols that will definitely be excluded
     missing_symbols = {s for s in (data.functions + data.variables) if s.include_rule != "never" and not hasattr(library, s.c_name())}
     if missing_symbols:
         if opts.include_missing_symbols:

--- a/ctypesgen/processor/operations.py
+++ b/ctypesgen/processor/operations.py
@@ -248,7 +248,7 @@ def check_symbols(data, opts):
         libraryloader._register_library(
             name = opts.library,
             dllclass = opts.dllclass,
-            dirs = list(set(opts.compile_libdirs)),
+            dirs = opts.compile_libdirs,
             search_sys = opts.allow_system_search,
             reldir = Path.cwd(),
         )

--- a/ctypesgen/processor/operations.py
+++ b/ctypesgen/processor/operations.py
@@ -247,7 +247,7 @@ def check_symbols(data, opts):
     try:
         libraryloader._register_library(
             name = opts.library,
-            dllclass = opts.dllclass,
+            dllclass = getattr(ctypes, opts.dllclass),
             dirs = opts.compile_libdirs,
             search_sys = opts.allow_system_search,
             reldir = Path.cwd(),

--- a/ctypesgen/processor/pipeline.py
+++ b/ctypesgen/processor/pipeline.py
@@ -78,13 +78,15 @@ def calculate_final_inclusion(data, opts):
 
     def can_include_desc(desc):
         if desc.can_include is None:
-            if desc.include_rule == "no":
+            if desc.include_rule == "never":
                 desc.can_include = False
             elif desc.include_rule == "yes" or desc.include_rule == "if_needed":
                 desc.can_include = True
                 for req in desc.requirements:
                     if not can_include_desc(req):
                         desc.can_include = False
+            else:
+                assert False, f"unknown include rule '{desc.include_rule}'"
         return desc.can_include
 
     def do_include_desc(desc):

--- a/tests/ctypesgentest.py
+++ b/tests/ctypesgentest.py
@@ -30,6 +30,9 @@ def ctypesgen_main(args):
 
 
 def module_from_code(name, python_code):
+    # exec'ed modules do not have __file__, but we could define it manually as an anchor point for relative paths (commented out because no test case needs this yet)
+    # file_spoof = f"__file__ = '{TEST_DIR/'spoof.py'}'\n\n"
+    # python_code = file_spoof + python_code
     module = types.ModuleType(name)
     exec(python_code, module.__dict__)
     return module

--- a/tests/ctypesgentest.py
+++ b/tests/ctypesgentest.py
@@ -1,11 +1,3 @@
-"""ctypesgentest is a simple module for testing ctypesgen on various C constructs.
-
-It consists of a single function, test(). test() takes a string that represents
-a C header file, along with some keyword arguments representing options. It
-processes the header using ctypesgen and returns a tuple containing the
-resulting module object and the output that ctypesgen produced.
-"""
-
 import os
 import sys
 import glob

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -107,7 +107,7 @@ class StdlibTest(unittest.TestCase):
             library = "msvcrt"
         else:
             library = "c"  # libc
-        cls.module = generate(header_str, ["-l", library, "--all-headers", "--symbol-rules", "if_needed=__\w+"])
+        cls.module = generate(header_str, ["-l", library, "--all-headers", "--symbol-rules", r"if_needed=__\w+"])
 
     @classmethod
     def tearDownClass(cls):
@@ -2047,7 +2047,7 @@ class MathTest(unittest.TestCase):
         # math.h contains a macro NAN = (0.0 / 0.0) which triggers a ZeroDivisionError on module import, so exclude the symbol.
         # Also exclude unused members starting with __ to avoid garbage in the output.
         # TODO consider adding options like --replace-symbol/--add-symbols/--add-imports so the caller could e.g. redefine NAN=math.nan
-        cls.module = generate(header_str, ["-l", library, "--all-headers", "--symbol-rules", "never=NAN", "if_needed=__\w+"])
+        cls.module = generate(header_str, ["-l", library, "--all-headers", "--symbol-rules", "never=NAN", r"if_needed=__\w+"])
 
     @classmethod
     def tearDownClass(cls):
@@ -2415,11 +2415,11 @@ class MainTest(unittest.TestCase):
 
     def test_invalid_option(self):
         """Test that script at least generates a help"""
-        o, e, c = self._exec(["-l", "placeholder", "--headers", "random_header.h", "--oh-what-a-goose-i-am"])
+        o, e, c = self._exec(["-i", "_", "-l", "_", "-o", "_", "--this-does-not-exist"])
         self.assertEqual(c, 2)
         self.assertEqual(o.decode(), "")
         self.assertTrue(e.decode().splitlines()[0].startswith("usage: run.py"))
-        self.assertIn("error: unrecognized arguments: --oh-what-a-goose-i-am", e.decode())
+        self.assertIn("error: unrecognized arguments: --this-does-not-exist", e.decode())
 
 
 class UncheckedTest(unittest.TestCase):

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -2043,7 +2043,7 @@ class MathTest(unittest.TestCase):
         elif sys.platform.startswith("linux"):
             library = "m"  # libm
         else:
-            library = "libc"
+            library = "c"  # libc
         # math.h contains a macro NAN = (0.0 / 0.0) which triggers a ZeroDivisionError on module import, so exclude the symbol.
         # Also exclude unused members starting with __ to avoid garbage in the output.
         # TODO consider adding options like --replace-symbol/--add-symbols/--add-imports so the caller could e.g. redefine NAN=math.nan


### PR DESCRIPTION
The intent behind this is to be able to share library handles with --no-embed-preamble in the future, through a dedicated file. With the idea in mind to bind to same-library headers separately without repeated library loading.

pypdfium2 adaptation is at https://github.com/pypdfium2-team/pypdfium2/tree/ctypesgen_library_sharing