### PR TITLE
Work on conflicting names resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,7 @@ See https://github.com/pypdfium2-team/ctypesgen/issues/1 for more.
 * We do not support binding to multiple binaries in the same output file. Instead, you'll want to create separate output files sharing the preamble, and possibly use module linking, as described above.
 
 *ctypesgen*
-* Conflicting names are detected, but not actually resolved recursively: any dependant symbols would currently get excluded from the output.
-  However, the scope of this issue should be somewhat limited, for structs and enums are prefixed as such and then aliased to their real name, and functions try to use the direct (prefixed) definition.
-  E.g. if you have a struct called `class`, the direct definition would be `struct_class`, and a function `foo(class* obj)` should be translated to `foo.argtypes = [POINTER(struct_class)]`.
+* The conflicting names resolver is currently untested, in particular the handling of dependants. Please report success or failure.
 
 
 ### Fork rationale

--- a/ctypesgen/__main__.py
+++ b/ctypesgen/__main__.py
@@ -349,7 +349,7 @@ def main(given_argv=sys.argv[1:]):
     args.runtime_libdirs = args.runtime_libdirs + args.universal_libdirs
     
     # Figure out what names will be defined by imported Python modules
-    args.imported_symbols = find_symbols_in_modules(args.modules, Path(args.output).resolve())
+    args.linked_symbols = find_symbols_in_modules(args.modules, Path(args.output).resolve())
     
     printer = {"py": printer_python, "json": printer_json}[args.output_language].WrapperPrinter
     descriptions = core_parser.parse(args.headers, args)

--- a/ctypesgen/processor/dependencies.py
+++ b/ctypesgen/processor/dependencies.py
@@ -20,7 +20,7 @@ def find_dependencies(data, opts):
 
     # Start the lookup tables with names from imported modules
 
-    for name in opts.imported_symbols:
+    for name in opts.linked_symbols:
         typedef_names[name] = None
         ident_names[name] = None
         if name.startswith("struct_") or name.startswith("enum_"):

--- a/ctypesgen/processor/operations.py
+++ b/ctypesgen/processor/operations.py
@@ -95,15 +95,17 @@ def fix_conflicting_names(data, opts):
     our_names |= {x for x in dir(ctypes) if not x.startswith("_")}
     
     # This dictionary maps names to a string representing where the name came from.
-    important_names = {}
+    protected_names = {}
     for name in our_names:
-        important_names[name] = "a name from ctypes or ctypesgen"
+        protected_names[name] = "a name from ctypes or ctypesgen"
     for name in dir(__builtins__):
-        important_names[name] = "a Python builtin"
-    for name in opts.imported_symbols:
-        important_names[name] = "a name from an included Python module"
+        protected_names[name] = "a Python builtin"
+    for name in opts.linked_symbols:
+        # note: the dependency resolver honors linked modules, but we can get conflicts with eagerly included symbols
+        # FIXME(geisserml) in case of intentional name shadowing, shouldn't we prioritize our input over linked modules ?
+        protected_names[name] = "a name from a linked Python module"
     for name in keyword.kwlist:
-        important_names[name] = "a Python keyword"
+        protected_names[name] = "a Python keyword"
     
     # This is the order of priority for names
     descriptions = (
@@ -116,47 +118,44 @@ def fix_conflicting_names(data, opts):
         + data.macros
     )
     
-    # FIXME(geisserml) This does not actually update dependents, just recursively exlcude them.
-    # However, I'm not sure why the rename is problem, as the dependants presumably store a reference to the mutable object, and dest strings should be evaluated lazyly ... ?
-    # That said, the scope of this issue should be somewhat limited due to the struct_* and enum_* prefixes, and functions trying to use the direct definition.
-    
     for desc in descriptions:
-        if desc.py_name() in important_names:
-            conflict_name = important_names[desc.py_name()]
-
-            original_name = desc.casual_name()
-            while desc.py_name() in important_names:
+        
+        if desc.py_name() in protected_names:
+        
+            conflict_cause = protected_names[desc.py_name()]
+            original_info = desc.casual_name()
+            while desc.py_name() in protected_names:
                 if isinstance(desc, (StructDescription, EnumDescription)):
                     desc.tag += "_"
                 else:
-                    desc.name = f"_{desc.name}"
+                    desc.name += "_"
             
-            message = f"{original_name} has been renamed to {desc.casual_name()} due to a name conflict with {conflict_name}."
+            message = f"{original_info} has been renamed to {desc.casual_name()} due to a name conflict with {conflict_cause}."
             if desc.dependents:
-                message += " Dependant objects will be excluded (FIXME)."
-                for dependent in desc.dependents:
-                    dependent.include_rule = "never"
+                # pre-requisite: no copying of desc objects throughout the pipeline
+                message += f" Dependants (should adapt implicitly): {desc.dependents}"
             desc.warning(message)
             
+            # Protect renamed symbols that are known to be included, since they diverge from the original input. We needn't generally protect included symbols, as the preprocessed symbol list should not contain duplicates.
+            # TODO(pipeline) should this be put between the two calculate_final_inclusion() steps to also do this for included if_needed symbols ?
             if desc.include_rule == "yes":
-                important_names[desc.py_name()] = desc.casual_name()
-
-    # Names of struct members don't conflict with much, but they can conflict
-    # with Python keywords.
-
+                protected_names[desc.py_name()] = desc.casual_name()
+    
+    # Names of struct members don't conflict with much, but they can conflict with Python keywords.
     for struct in data.structs:
         if struct.opaque: continue  # no members
         for i, (name, type) in enumerate(struct.members):
+            # it should be safe to expect there will be no underscored sibling to a keyword, so we needn't loop
             if name in keyword.kwlist:
-                struct.members[i] = (f"_{name}", type)
+                name += "_"
+                struct.members[i] = (name, type)
                 struct.warning(
-                    f"Member '{name}' of {struct.casual_name()} has been renamed to '_{name}' because it has the same name as a Python keyword.",
+                    f"Member '{name}' of {struct.casual_name()} has been renamed to '{name}_' because it has the same name as a Python keyword.",
                     cls="rename",
                 )
 
     # Macro arguments may be have names that conflict with Python keywords.
     # TODO actually rename parameter
-
     for macro in data.macros:
         if not macro.params: continue  # may be None
         for param in macro.params:
@@ -207,7 +206,7 @@ def check_symbols(data, opts):
     
     try:
         # don't bother checking symbols that will definitely be excluded
-        # TODO consider doing this in between the two calculate_final_inclusion() steps to also skip if_needed symbols that won't be part of the output.
+        # TODO(pipeline) should this be put between the two calculate_final_inclusion() calls to skip if_needed symbols that won't be part of the output ?
         missing_symbols = {s for s in (data.functions + data.variables) if s.include_rule != "never" and not hasattr(library, s.c_name())}
     finally:
         free_library(library._handle)


### PR DESCRIPTION
This removes the exclusion of dependants, because I believe dependants might adapt automatically due to the object reference model with deferred py_string evaluation.