### PR TITLE
Include statements parsing draft

### DIFF
--- a/ctypesgen/includes.py
+++ b/ctypesgen/includes.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 INCLUDE_RE = re.compile(rb'^\s*\#include\s+(["<][^">]+[">])', re.MULTILINE)
 
-def gather_indirect_includes(filepaths, anchor):
+def gather_includes(filepaths, anchor):
     includes = {}
     for fp in filepaths:
-        key = Path(fp).relative_to(anchor)
+        key = str(Path(fp).relative_to(anchor))
         includes[key] = []
         with open(fp, "rb") as fh:
             mm = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
@@ -19,10 +19,23 @@ def gather_indirect_includes(filepaths, anchor):
 def filter_relative_includes(includes):
     includes = includes.copy()
     for key, file_includes in includes.items():
-        includes[key] = [m.group(1) for i in file_includes if (m := re.match(rb'"(.+)"', i))]
+        includes[key] = [m.group(1).decode() for i in file_includes if (m := re.match(rb'"(.+)"', i))]
     return includes
 
 
-def resolve_header_linkage(includes):
-    # TODO start with files that have empty lists, then pop these from all others, and recurse until we have resolved everything
-    pass
+def resolve_header_linkage(orig_includes):
+    order = []
+    includes = orig_includes.copy()
+    while True:
+        satisfied = [p for p, deps in includes.items() if not deps]
+        if not satisfied:
+            if includes:
+                raise RuntimeError(f"Some dependencies could not be satisfied: {includes}")
+            break
+        for s in satisfied:
+            order.append(s)
+            includes.pop(s)
+        for key, deps in includes.items():
+            includes[key] = [d for d in deps if d not in satisfied]
+    assert len(order) == len(orig_includes)
+    return order

--- a/ctypesgen/includes.py
+++ b/ctypesgen/includes.py
@@ -1,0 +1,18 @@
+import re
+import mmap
+
+
+INCLUDE_RE = re.compile(rb'^\s*\#include\s+(["<][^">]+[">])', re.MULTILINE)
+
+def gather_indirect_includes(filepaths):
+    includes = {}
+    for fp in filepaths:
+        includes[fp] = []
+        with open(fp, "rb") as fh:
+            mm = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
+            includes[fp] += INCLUDE_RE.findall(mm)
+    return includes
+
+
+def resolve_header_deptree():
+    pass

--- a/ctypesgen/includes.py
+++ b/ctypesgen/includes.py
@@ -1,18 +1,28 @@
 import re
 import mmap
+from pathlib import Path
 
 
 INCLUDE_RE = re.compile(rb'^\s*\#include\s+(["<][^">]+[">])', re.MULTILINE)
 
-def gather_indirect_includes(filepaths):
+def gather_indirect_includes(filepaths, anchor):
     includes = {}
     for fp in filepaths:
-        includes[fp] = []
+        key = Path(fp).relative_to(anchor)
+        includes[key] = []
         with open(fp, "rb") as fh:
             mm = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
-            includes[fp] += INCLUDE_RE.findall(mm)
+            includes[key] += INCLUDE_RE.findall(mm)
     return includes
 
 
-def resolve_header_deptree():
+def filter_relative_includes(includes):
+    includes = includes.copy()
+    for key, file_includes in includes.items():
+        includes[key] = [m.group(1) for i in file_includes if (m := re.match(rb'"(.+)"', i))]
+    return includes
+
+
+def resolve_header_linkage(includes):
+    # TODO start with files that have empty lists, then pop these from all others, and recurse until we have resolved everything
     pass

--- a/ctypesgen/page_per_header.py
+++ b/ctypesgen/page_per_header.py
@@ -1,0 +1,8 @@
+ 
+
+def main():
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/test_includes.py
+++ b/test_includes.py
@@ -1,9 +1,10 @@
 from pathlib import Path
-from ctypesgen.includes import gather_indirect_includes
+from ctypesgen.includes import *
 import rich
 
 headers_dir = Path("~/projects/pypdfium2/data/bindings/headers/").expanduser()
 filepaths = list(headers_dir.glob("*.h"))
 
-includes = gather_indirect_includes(filepaths)
-rich.print(includes)
+all_includes = gather_indirect_includes(filepaths, headers_dir)
+rel_includes = filter_relative_includes(all_includes)
+rich.print(rel_includes)

--- a/test_includes.py
+++ b/test_includes.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from ctypesgen.includes import gather_indirect_includes
+import rich
+
+headers_dir = Path("~/projects/pypdfium2/data/bindings/headers/").expanduser()
+filepaths = list(headers_dir.glob("*.h"))
+
+includes = gather_indirect_includes(filepaths)
+rich.print(includes)

--- a/test_includes.py
+++ b/test_includes.py
@@ -5,6 +5,9 @@ import rich
 headers_dir = Path("~/projects/pypdfium2/data/bindings/headers/").expanduser()
 filepaths = list(headers_dir.glob("*.h"))
 
-all_includes = gather_indirect_includes(filepaths, headers_dir)
+all_includes = gather_includes(filepaths, headers_dir)
+rich.print(all_includes)
 rel_includes = filter_relative_includes(all_includes)
 rich.print(rel_includes)
+order = resolve_header_linkage(rel_includes)
+rich.print(order)


### PR DESCRIPTION
A fun side project showing how to parse out include statements in python.
Might be useful in the future for `--deepen-inclusion 1` (rather than `--all-headers`), or for a wrapper to write individual outputs per header.

However, there might be some more elegant pre-processor mechanism to handle these cases.
See also this thread: https://stackoverflow.com/questions/5834778/how-to-tell-where-a-header-file-is-included-from

I'm opening and closing this PR just to record the idea and the code snippet, so it may be picked up later.