### PR TITLE
Include statements parsing draft (capture 2)

### DIFF
--- a/ctypesgen/includes.py
+++ b/ctypesgen/includes.py
@@ -1,0 +1,44 @@
+import re
+import mmap
+
+
+INCLUDE_RE = re.compile(rb'^\s*\#include\s+(["<][^">]+[">])', re.MULTILINE)
+
+def _get_path(name, dirs):
+    for d in dirs:
+        path = (d/name).resolve()
+        if path.exists(): return path
+    assert False, f'Could not resolve #include "{name}" to full path'
+
+def gather_includes(filepaths, search_dirs=[]):
+    raw, sys, rel = {}, {}, {}
+    for p in filepaths:
+        raw[p], sys[p], rel[p] = [], [], []
+        with p.open("rb") as fh:
+            data = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
+            for include in INCLUDE_RE.finditer(data):
+                include = include.group(1).decode()
+                raw[p].append(include)
+                if m := re.fullmatch(r'<(.+)>', include):
+                    sys[p].append( m.group(1) )
+                elif m := re.fullmatch(r'"(.+)"', include):
+                    rel[p].append( _get_path(m.group(1), [p.parent, *search_dirs]) )
+                else:
+                    assert False
+    return raw, sys, rel
+
+
+def resolve_header_order(orig_includes):
+    order = []
+    includes = orig_includes.copy()
+    while includes:
+        satisfied = [p for p, deps in includes.items() if not deps]
+        if not satisfied:
+            raise RuntimeError(f"Unsatisfiable dependencies at resolution state {includes}")
+        for s in satisfied:
+            order.append(s)
+            includes.pop(s)
+        for key, deps in includes.items():
+            includes[key] = [d for d in deps if d not in satisfied]
+    assert len(order) == len(orig_includes)
+    return order

--- a/ctypesgen/page_per_header.py
+++ b/ctypesgen/page_per_header.py
@@ -1,0 +1,8 @@
+ 
+
+def main():
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/test_includes.py
+++ b/test_includes.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from ctypesgen.includes import *
+import rich
+
+headers_dir = Path("~/projects/pypdfium2/data/bindings/headers/").expanduser()
+filepaths = list(headers_dir.glob("**/*.h"))
+
+all, sys, rel = gather_includes(filepaths, search_dirs=[headers_dir])
+rich.print(all, sys, rel)
+order = resolve_header_order(rel)
+rich.print(order)


### PR DESCRIPTION
Reland of https://github.com/pypdfium2-team/ctypesgen/pull/9

> A fun side project showing how to parse out include statements in python.
Might be useful in the future for --deepen-inclusion 1 (rather than --all-headers), or for a wrapper to write individual outputs per header.

> However, there might be some more elegant pre-processor mechanism to handle these cases.
See also this thread: https://stackoverflow.com/questions/5834778/how-to-tell-where-a-header-file-is-included-from
