### PR TITLE
Slightly modernize unnamed fields handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,6 @@ name = "ctypesgen"
 description = "Python wrapper generator for ctypes"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
     "Development Status :: 4 - Beta",
     "Operating System :: OS Independent",
@@ -21,7 +17,7 @@ classifiers = [
     "Environment :: Console",
 ]
 dynamic = ["readme", "version", "license"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "https://github.com/ctypesgen/ctypesgen"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,12 @@ name = "ctypesgen"
 description = "Python wrapper generator for ctypes"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Development Status :: 4 - Beta",
     "Operating System :: OS Independent",

--- a/src/ctypesgen/ctypedescs.py
+++ b/src/ctypesgen/ctypedescs.py
@@ -288,7 +288,7 @@ def anon_struct_tagnum():
 
 class CtypesStruct(CtypesType):
     def __init__(self, tag, attrib, variety, members, src=None):
-        super(CtypesStruct, self).__init__()
+        super().__init__()
         self.tag = tag
         self.attrib = attrib
         self.variety = variety  # "struct" or "union"
@@ -302,7 +302,7 @@ class CtypesStruct(CtypesType):
     
 
     def get_required_types(self):
-        types = super(CtypesStruct, self).get_required_types()
+        types = super().get_required_types()
         types.add((self.variety, self.tag))
         return types
 
@@ -311,7 +311,7 @@ class CtypesStruct(CtypesType):
         if not self.opaque:
             for name, ctype in self.members:
                 ctype.visit(visitor)
-        super(CtypesStruct, self).visit(visitor)
+        super().visit(visitor)
 
     def get_subtypes(self):
         return set() if self.opaque else {m[1] for m in self.members}

--- a/src/ctypesgen/printer_python.py
+++ b/src/ctypesgen/printer_python.py
@@ -232,22 +232,9 @@ _register_library(
         self.file.write(entry)
     
     
-    # FIXME(geisserml) This looks like evaluation work that doesn't belong to the printer, but to an earlier part of the control flow...
-    
-    def _gen_unnamed_fields(self, struct):
-        # handle unnamed fields
-        names = set(n for n, *_ in struct.members)
-        n = 1
-        for mi, (mem_name, mem_type, *mem_other) in enumerate(struct.members):
-            if mem_name is not None: continue
-            while (name := f"unnamed_{n}") in names:
-                n += 1
-            names.add(name)
-            if type(mem_type) is CtypesStruct:
-                yield name
-            struct.members[mi] = (name, mem_type, *mem_other)
-    
     def _handle_struct_extras(self, struct):
+        
+        # FIXME(geisserml) This looks like evaluation work that doesn't belong to the printer, but to an earlier part of the control flow...
         
         # is this supposed to be packed?
         aligned = None
@@ -259,10 +246,21 @@ _register_library(
                 # FIXME for non-constant expression nodes, this will fail
                 aligned = aligned.evaluate(None)
         
-        unnamed_fields = tuple( self._gen_unnamed_fields(struct) )
+        # handle unnamed fields
+        unnamed_fields = []
+        names = set(n for n, *_ in struct.members)
+        n = 1
+        for mi, (mem_name, mem_type, *mem_other) in enumerate(struct.members):
+            if mem_name is not None: continue
+            while (name := f"unnamed_{n}") in names:
+                n += 1
+            names.add(name)
+            if type(mem_type) is CtypesStruct:
+                unnamed_fields.append(name)
+            struct.members[mi] = (name, mem_type, *mem_other)
         
-        return aligned, unnamed_fields
-
+        return aligned, tuple(unnamed_fields)
+    
     
     def print_struct(self, struct):
         # input produced by CtypesParser.make_struct_from_specifier()

--- a/src/ctypesgen/printer_python.py
+++ b/src/ctypesgen/printer_python.py
@@ -255,7 +255,7 @@ _register_library(
             while (name := f"unnamed_{n}") in names:
                 n += 1
             names.add(name)
-            if type(mem_type) is CtypesStruct:
+            if isinstance(mem_type, CtypesStruct):
                 unnamed_fields.append(name)
             struct.members[mi] = (name, mem_type, *mem_other)
         

--- a/src/ctypesgen/printer_python.py
+++ b/src/ctypesgen/printer_python.py
@@ -248,21 +248,19 @@ _register_library(
         
         # handle unnamed fields
         unnamed_fields = []
-        names = set([x[0] for x in struct.members])
+        names = set(x[0] for x in struct.members)
         n = 1
-        for mi in range(len(struct.members)):
-            mem = list(struct.members[mi])
-            if mem[0] is None:
-                while True:
-                    name = f"unnamed_{n}"
-                    n += 1
-                    if name not in names:
-                        break
-                mem[0] = name
-                names.add(name)
-                if type(mem[1]) is CtypesStruct:
-                    unnamed_fields.append(name)
-                struct.members[mi] = mem
+        for mi, mem in enumerate(struct.members):
+            if mem[0] is not None:
+                continue
+            while (name := f"unnamed_{n}") in names:
+                n += 1
+            mem = list(mem)
+            mem[0] = name
+            names.add(name)
+            if type(mem[1]) is CtypesStruct:
+                unnamed_fields.append(name)
+            struct.members[mi] = mem
         
         return aligned, tuple(unnamed_fields)
 


### PR DESCRIPTION
Python doesn't have classical do-while loops, but an assignment expression can nicely simplify this clause.
Requires Python >= 3.8.

Also, use enumerate() and remove an unnecessary listcomp layer on set construction.