### PR TITLE
Drop legacy super(...) everywhere

### DIFF
--- a/src/ctypesgen/ctypedescs.py
+++ b/src/ctypesgen/ctypedescs.py
@@ -134,7 +134,7 @@ def remove_function_pointer(t):
 
 class CtypesType:
     def __init__(self):
-        super(CtypesType, self).__init__()
+        super().__init__()
         self.errors = []
 
     def __repr__(self):
@@ -152,7 +152,7 @@ class CtypesSimple(CtypesType):
     """Represents a builtin type, like "char" or "int"."""
 
     def __init__(self, name, signed, longs):
-        super(CtypesSimple, self).__init__()
+        super().__init__()
         self.name = name
         self.signed = signed
         self.longs = longs
@@ -163,7 +163,7 @@ class CtypesSimple(CtypesType):
 
 class CtypesSpecial(CtypesType):
     def __init__(self, name):
-        super(CtypesSpecial, self).__init__()
+        super().__init__()
         self.name = name
 
     def py_string(self, ignore_can_be_ctype=None):
@@ -174,13 +174,13 @@ class CtypesTypedef(CtypesType):
     """Represents a type defined by a typedef."""
 
     def __init__(self, name):
-        super(CtypesTypedef, self).__init__()
+        super().__init__()
         self.name = name
 
     def visit(self, visitor):
         if not self.errors:
             visitor.visit_typedef(self.name)
-        super(CtypesTypedef, self).visit(visitor)
+        super().visit(visitor)
 
     def py_string(self, ignore_can_be_ctype=None):
         return self.name
@@ -188,13 +188,13 @@ class CtypesTypedef(CtypesType):
 
 class CtypesBitfield(CtypesType):
     def __init__(self, base, bitfield):
-        super(CtypesBitfield, self).__init__()
+        super().__init__()
         self.base = base
         self.bitfield = bitfield
 
     def visit(self, visitor):
         self.base.visit(visitor)
-        super(CtypesBitfield, self).visit(visitor)
+        super().visit(visitor)
 
     def py_string(self, ignore_can_be_ctype=None):
         return self.base.py_string()
@@ -202,14 +202,14 @@ class CtypesBitfield(CtypesType):
 
 class CtypesPointer(CtypesType):
     def __init__(self, destination, qualifiers):
-        super(CtypesPointer, self).__init__()
+        super().__init__()
         self.destination = destination
         self.qualifiers = qualifiers
 
     def visit(self, visitor):
         if self.destination:
             self.destination.visit(visitor)
-        super(CtypesPointer, self).visit(visitor)
+        super().visit(visitor)
 
     def py_string(self, ignore_can_be_ctype=None):
         return "POINTER(%s)" % self.destination.py_string()
@@ -217,7 +217,7 @@ class CtypesPointer(CtypesType):
 
 class CtypesArray(CtypesType):
     def __init__(self, base, count):
-        super(CtypesArray, self).__init__()
+        super().__init__()
         self.base = base
         self.count = count
 
@@ -225,7 +225,7 @@ class CtypesArray(CtypesType):
         self.base.visit(visitor)
         if self.count:
             self.count.visit(visitor)
-        super(CtypesArray, self).visit(visitor)
+        super().visit(visitor)
 
     def py_string(self, ignore_can_be_ctype=None):
         if self.count is None:
@@ -250,7 +250,7 @@ class CtypesNoErrorCheck:
 
 class CtypesFunction(CtypesType):
     def __init__(self, restype, parameters, variadic, options, attrib=None):
-        super(CtypesFunction, self).__init__()
+        super().__init__()
         self.restype = restype
         self.errcheck = CtypesNoErrorCheck()
         self.argtypes = [remove_function_pointer(p) for p in parameters]
@@ -269,7 +269,7 @@ class CtypesFunction(CtypesType):
         self.restype.visit(visitor)
         for a in self.argtypes:
             a.visit(visitor)
-        super(CtypesFunction, self).visit(visitor)
+        super().visit(visitor)
 
     def py_string(self, ignore_can_be_ctype=None):
         return "CFUNCTYPE(UNCHECKED(%s), %s)" % (
@@ -330,7 +330,7 @@ def anon_enum_tag():
 
 class CtypesEnum(CtypesType):
     def __init__(self, tag, enumerators, src=None):
-        super(CtypesEnum, self).__init__()
+        super().__init__()
         self.tag = tag
         self.anonymous = not self.tag
         if self.anonymous:
@@ -341,7 +341,7 @@ class CtypesEnum(CtypesType):
 
     def visit(self, visitor):
         visitor.visit_enum(self)
-        super(CtypesEnum, self).visit(visitor)
+        super().visit(visitor)
 
     def py_string(self, ignore_can_be_ctype=None):
         return f"enum_{self.tag}"

--- a/src/ctypesgen/descriptions.py
+++ b/src/ctypesgen/descriptions.py
@@ -29,7 +29,7 @@ class Description:
     or macro description. Description is an abstract base class."""
 
     def __init__(self, src=None):
-        super(Description, self).__init__()
+        super().__init__()
         self.src = src  # A tuple of (filename, lineno)
 
         # If object will be included in output file. Values are "yes", "never",
@@ -82,7 +82,7 @@ class ConstantDescription(Description):
     """Simple class to contain information about a constant."""
 
     def __init__(self, name, value, src=None):
-        super(ConstantDescription, self).__init__(src)
+        super().__init__(src)
         # Name of constant, a string
         self.name = name
         # Value of constant, as an ExpressionNode object
@@ -102,7 +102,7 @@ class TypedefDescription(Description):
     """Simple container class for a type definition."""
 
     def __init__(self, name, ctype, src=None):
-        super(TypedefDescription, self).__init__(src)
+        super().__init__(src)
         self.name = name  # Name, a string
         self.ctype = ctype  # The base type as a ctypedescs.CtypeType object
 
@@ -120,7 +120,7 @@ class StructDescription(Description):
     """Simple container class for a structure or union definition."""
 
     def __init__(self, tag, attrib, variety, members, opaque, ctype, src=None):
-        super(StructDescription, self).__init__(src)
+        super().__init__(src)
         # The name of the structure minus the "struct" or "union"
         self.tag = tag
         self.attrib = attrib
@@ -147,7 +147,7 @@ class EnumDescription(Description):
     """Simple container class for an enum definition."""
 
     def __init__(self, tag, members, ctype, src=None):
-        super(EnumDescription, self).__init__(src)
+        super().__init__(src)
         # The name of the enum, minus the "enum"
         self.tag = tag
         # A list of (name,value) pairs where value is a number
@@ -169,7 +169,7 @@ class FunctionDescription(Description):
     """Simple container class for a C function."""
 
     def __init__(self, name, restype, argtypes, errcheck, variadic, attrib, src):
-        super(FunctionDescription, self).__init__(src)
+        super().__init__(src)
         # Name, a string
         self.name = name
         # Name according to C - stored in case description is renamed
@@ -199,7 +199,7 @@ class VariableDescription(Description):
     """Simple container class for a C variable declaration."""
 
     def __init__(self, name, ctype, src=None):
-        super(VariableDescription, self).__init__(src)
+        super().__init__(src)
         # Name, a string
         self.name = name
         # Name according to C - stored in case description is renamed
@@ -221,7 +221,7 @@ class MacroDescription(Description):
     """Simple container class for a C macro."""
 
     def __init__(self, name, params, expr, src=None):
-        super(MacroDescription, self).__init__(src)
+        super().__init__(src)
         self.name = name
         self.params = params
         self.expr = expr  # ExpressionNode for the macro's body
@@ -240,7 +240,7 @@ class UndefDescription(Description):
     """Simple container class for a preprocessor #undef directive."""
 
     def __init__(self, macro, src=None):
-        super(UndefDescription, self).__init__(src)
+        super().__init__(src)
         self.include_rule = "if_needed"
         self.macro = macro
 

--- a/src/ctypesgen/parser/cdeclarations.py
+++ b/src/ctypesgen/parser/cdeclarations.py
@@ -55,14 +55,14 @@ class Pointer(Declarator):
     pointer = None
 
     def __init__(self):
-        super(Pointer, self).__init__()
+        super().__init__()
         self.qualifiers = []
 
     def __repr__(self):
         q = ""
         if self.qualifiers:
             q = "<%s>" % " ".join(self.qualifiers)
-        return "POINTER%s(%r)" % (q, self.pointer) + super(Pointer, self).__repr__()
+        return "POINTER%s(%r)" % (q, self.pointer) + super().__repr__()
 
 
 class Array:
@@ -230,17 +230,17 @@ pragma_pack = PragmaPack()
 class Attrib(dict):
     def __init__(self, *a, **kw):
         if pragma_pack.current:
-            super(Attrib, self).__init__(packed=True, aligned=[pragma_pack.current])
-            super(Attrib, self).update(*a, **kw)
+            super().__init__(packed=True, aligned=[pragma_pack.current])
+            super().update(*a, **kw)
         else:
-            super(Attrib, self).__init__(*a, **kw)
+            super().__init__(*a, **kw)
         self._unalias()
 
     def __repr__(self):
         return f"Attrib({dict(self)})"
 
     def update(self, *a, **kw):
-        super(Attrib, self).update(*a, **kw)
+        super().update(*a, **kw)
         self._unalias()
 
     def _unalias(self):

--- a/src/ctypesgen/parser/cparser.py
+++ b/src/ctypesgen/parser/cparser.py
@@ -83,7 +83,7 @@ class CParser:
     """
 
     def __init__(self, options):
-        super(CParser, self).__init__()
+        super().__init__()
         self.preprocessor_parser = preprocessor.PreprocessorParser(options, self)
         self.parser = yacc.yacc(
             method="LALR",

--- a/src/ctypesgen/parser/ctypesparser.py
+++ b/src/ctypesgen/parser/ctypesparser.py
@@ -80,7 +80,7 @@ class CtypesParser(CParser):
     """
 
     def __init__(self, options):
-        super(CtypesParser, self).__init__(options)
+        super().__init__(options)
         self.options = options
         self.type_map = ctypes_type_map
         if not self.options.no_python_types:

--- a/src/ctypesgen/parser/datacollectingparser.py
+++ b/src/ctypesgen/parser/datacollectingparser.py
@@ -34,7 +34,7 @@ class DataCollectingParser(ctypesparser.CtypesParser, CtypesTypeVisitor):
     """
 
     def __init__(self, headers, options):
-        super(DataCollectingParser, self).__init__(options)
+        super().__init__(options)
         self.headers = headers
         self.options = options
 
@@ -78,7 +78,7 @@ class DataCollectingParser(ctypesparser.CtypesParser, CtypesTypeVisitor):
                 f.write(f'#include "{header}"\n')
             f.flush()
         try:
-            super(DataCollectingParser, self).parse(fname, self.options.debug_level)
+            super().parse(fname, self.options.debug_level)
         finally:
             os.unlink(fname)
 


### PR DESCRIPTION
Created via regex search & replace:
`super\(\w+, self\)` -> `super()`